### PR TITLE
feat(ui): add LoggedStatusButton component

### DIFF
--- a/src/OktoProvider.tsx
+++ b/src/OktoProvider.tsx
@@ -51,8 +51,9 @@ import {
 import { storeJSONLocalStorage, getJSONLocalStorage } from "./utils/storage";
 import { OktoModal } from "./components/OktoModal";
 import { OnboardingModal } from "./components/OnboardingModal";
+import LoggedStatusButton from "./components/LoggedStatusButton";
 
-const OktoContext = createContext<OktoContextType | null>(null);
+export const OktoContext = createContext<OktoContextType | null>(null);
 
 export const OktoProvider = ({
   children,
@@ -596,6 +597,7 @@ export const OktoProvider = ({
   return (
     <OktoContext.Provider
       value={{
+        LoggedStatusButton,
         isLoggedIn,
         authenticate,
         authenticateWithUserId,

--- a/src/components/LoggedStatusButton.module.css
+++ b/src/components/LoggedStatusButton.module.css
@@ -1,0 +1,63 @@
+.buttonContainer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background-color: #ffffff;
+  border-radius: 8px;
+  padding: 12px 16px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease-in-out;
+}
+
+.statusIndicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  transition: background-color 0.3s ease-in-out;
+}
+
+.online {
+  background-color: #4caf50; /* Green */
+}
+
+.offline {
+  background-color: #f44336; /* Red */
+}
+
+.statusText {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333333;
+}
+
+@media (max-width: 768px) {
+  .buttonContainer {
+    padding: 8px 12px;
+    gap: 8px;
+  }
+
+  .statusIndicator {
+    width: 10px;
+    height: 10px;
+  }
+
+  .statusText {
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .buttonContainer {
+    padding: 6px 10px;
+    gap: 6px;
+  }
+
+  .statusIndicator {
+    width: 8px;
+    height: 8px;
+  }
+
+  .statusText {
+    font-size: 10px;
+  }
+}

--- a/src/components/LoggedStatusButton.tsx
+++ b/src/components/LoggedStatusButton.tsx
@@ -1,27 +1,33 @@
-import React, { useContext } from "react";
-import { OktoContext } from "../OktoProvider";
+import React, { forwardRef, useImperativeHandle, useState } from "react";
+import styles from "./LoggedStatusButton.module.css";
 
-const LoggedStatusButton: React.FC = () => {
-  const context = useContext(OktoContext);
+interface StatusButtonRef {
+  toggleStatus: () => void;
+}
 
-  if (!context) {
-    return null;
-  }
+const LoggedStatusButton: React.FC<{}> = forwardRef((_, ref) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
-  const { isLoggedIn } = context;
+  const toggleStatus = () => {
+    setIsLoggedIn((prevStatus) => !prevStatus);
+  };
+
+  useImperativeHandle(ref, () => ({
+    toggleStatus,
+  }));
 
   return (
-    <div className="flex items-center gap-2 bg-white rounded-lg px-4 py-2 shadow-sm">
+    <div className={styles.buttonContainer}>
       <div
-        className={`w-3 h-3 rounded-full ${
-          isLoggedIn ? "bg-green-500" : "bg-red-500"
+        className={`${styles.statusIndicator} ${
+          isLoggedIn ? styles.online : styles.offline
         }`}
       ></div>
-      <span className="text-sm font-medium">
+      <span className={styles.statusText}>
         Status: {isLoggedIn ? "Logged In" : "Not Logged In"}
       </span>
     </div>
   );
-};
+});
 
 export default LoggedStatusButton;

--- a/src/components/LoggedStatusButton.tsx
+++ b/src/components/LoggedStatusButton.tsx
@@ -1,0 +1,27 @@
+import React, { useContext } from "react";
+import { OktoContext } from "../OktoProvider";
+
+const LoggedStatusButton: React.FC = () => {
+  const context = useContext(OktoContext);
+
+  if (!context) {
+    return null;
+  }
+
+  const { isLoggedIn } = context;
+
+  return (
+    <div className="flex items-center gap-2 bg-white rounded-lg px-4 py-2 shadow-sm">
+      <div
+        className={`w-3 h-3 rounded-full ${
+          isLoggedIn ? "bg-green-500" : "bg-red-500"
+        }`}
+      ></div>
+      <span className="text-sm font-medium">
+        Status: {isLoggedIn ? "Logged In" : "Not Logged In"}
+      </span>
+    </div>
+  );
+};
+
+export default LoggedStatusButton;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export enum AuthType {
 }
 
 export interface OktoContextType {
+  LoggedStatusButton: React.FC;
   isLoggedIn: boolean;
   authenticate: (
     idToken: string,


### PR DESCRIPTION
Added LoggedStatusButton component which can be easily used within the code : 

```
import { useOkto, OktoContextType } from "okto-sdk-react";
const { LoggedStatusButton } = useOkto() as OktoContextType;

<LoggedStatusButton/>
```

LoggedStatusButton utilises isLoggedIn to determine whether the user is logged in our not.

Testing : 
I build this as a npm link and used within my application : 
<img width="268" alt="image" src="https://github.com/user-attachments/assets/1f34f79b-37f6-4a64-9728-b8d8e5371131">


